### PR TITLE
Block/Item disambiguation

### DIFF
--- a/B/items/crop/wild_beetroots.json
+++ b/B/items/crop/wild_beetroots.json
@@ -18,7 +18,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:wild_beetroots",
+      "identifier": "farmersdelight:wild_beetroots_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/items/crop/wild_cabbages.json
+++ b/B/items/crop/wild_cabbages.json
@@ -18,7 +18,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:wild_cabbages",
+      "identifier": "farmersdelight:wild_cabbages_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/items/crop/wild_carrots.json
+++ b/B/items/crop/wild_carrots.json
@@ -18,7 +18,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:wild_carrots",
+      "identifier": "farmersdelight:wild_carrots_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/items/crop/wild_onions.json
+++ b/B/items/crop/wild_onions.json
@@ -18,7 +18,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:wild_onions",
+      "identifier": "farmersdelight:wild_onions_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/items/crop/wild_potatoes.json
+++ b/B/items/crop/wild_potatoes.json
@@ -18,7 +18,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:wild_potatoes",
+      "identifier": "farmersdelight:wild_potatoes_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/items/crop/wild_rice.json
+++ b/B/items/crop/wild_rice.json
@@ -18,7 +18,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:wild_rice",
+      "identifier": "farmersdelight:wild_rice_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/items/crop/wild_tomatoes.json
+++ b/B/items/crop/wild_tomatoes.json
@@ -18,7 +18,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:wild_tomatoes",
+      "identifier": "farmersdelight:wild_tomatoes_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/items/rope.json
+++ b/B/items/rope.json
@@ -12,7 +12,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:rope",
+      "identifier": "farmersdelight:rope_item",
       "menu_category": {
         "category": "Items",
         "group": "itemGroup.name.items"

--- a/B/items/sandy_shrub.json
+++ b/B/items/sandy_shrub.json
@@ -17,7 +17,7 @@
       }
     },
     "description": {
-      "identifier": "farmersdelight:sandy_shrub",
+      "identifier": "farmersdelight:sandy_shrub_item",
       "menu_category": {
         "category": "nature",
         "group": "itemGroup.name.nature"

--- a/B/loot_tables/farmersdelight/rope.json
+++ b/B/loot_tables/farmersdelight/rope.json
@@ -5,7 +5,7 @@
             "entries": [
                 {
                     "type": "item",
-                    "name": "farmersdelight:rope"
+                    "name": "farmersdelight:rope_item"
                 }
             ]
         }

--- a/B/recipes/normal/rope.json
+++ b/B/recipes/normal/rope.json
@@ -19,7 +19,7 @@
         },
         "result": [
             {
-                "item": "farmersdelight:rope",
+                "item": "farmersdelight:rope_item",
                 "count": 3
             }
         ]


### PR DESCRIPTION
These items had the same identifier as the blocks, which causes errors on the console. 

#16 

In the case of Rope, it was more serious, because loot/recipes were ignoring the rope item, and returning the rope block instead.