### PR TITLE
Feat: 新增`farmersdelight:dish`组件

### DIFF
--- a/B/blocks/honey_glazed_ham_block.json
+++ b/B/blocks/honey_glazed_ham_block.json
@@ -1,168 +1,177 @@
 {
-    "format_version": "1.21.120",
-    "minecraft:block": {
-        "description": {
-            "identifier": "farmersdelight:honey_glazed_ham_block",
-            "menu_category": {
-                "category": "none"
-            },
-            "states": {
-                "farmersdelight:food_block_stage": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4
-                ]
-            },
-            "traits": {
-                "minecraft:placement_direction": {
-                    "enabled_states": [
-                        "minecraft:cardinal_direction"
-                    ],
-                    "y_rotation_offset": 0.0
-                }
-            }
-        },
-        "permutations": [
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
-                "components": {
-                    "minecraft:geometry": "geometry.honey_glazed_ham_block_stage0"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
-                "components": {
-                    "minecraft:geometry": "geometry.honey_glazed_ham_block_stage1"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
-                "components": {
-                    "minecraft:geometry": "geometry.honey_glazed_ham_block_stage2"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
-                "components": {
-                    "minecraft:geometry": "geometry.honey_glazed_ham_block_stage3"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
-                "components": {
-                    "minecraft:geometry": "geometry.honey_glazed_ham_block_leftover"
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            180,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            0,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            270,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            90,
-                            0
-                        ]
-                    }
-                }
-            }
-        ],
-        "components": {
-            "minecraft:geometry": "geometry.honey_glazed_ham_block_stage0",
-            "minecraft:redstone_conductivity": {
-                "allows_wire_to_step_down": false
-            },
-            "minecraft:destructible_by_mining": {
-                "seconds_to_destroy": 1.0
-            },
-            "minecraft:light_dampening": 0,
-            "minecraft:destructible_by_explosion": {
-                "explosion_resistance": 0.25
-            },
-            "minecraft:material_instances": {
-                "*": {
-                    "texture": "honey_glazed_ham_body"
-                },
-                "honey_glazed_ham_bone": {
-                    "texture": "honey_glazed_ham_bone"
-                },
-                "honey_glazed_ham_body": {
-                    "texture": "honey_glazed_ham_body"
-                },
-                "tray_bottom": {
-                    "texture": "tray_bottom"
-                },
-                "tray_rice_berry_garnish": {
-                    "texture": "tray_rice_berry_garnish"
-                },
-                "tray_rice_berry_leftover": {
-                    "texture": "tray_rice_berry_leftover"
-                }
-            },
-            "minecraft:collision_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    10.0,
-                    14.0
-                ]
-            },
-            "minecraft:selection_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    10.0,
-                    14.0
-                ]
-            },
-            "farmersdelight:interact": {},
-            "tag:farmersdelight.blockfood:4-item.minecraft:bowl": {},
-            "tag:farmersdelight:blockfood": {}
+  "format_version": "1.21.120",
+  "minecraft:block": {
+    "description": {
+      "identifier": "farmersdelight:honey_glazed_ham_block",
+      "menu_category": {
+        "category": "none"
+      },
+      "states": {
+        "farmersdelight:food_block_stage": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      "traits": {
+        "minecraft:placement_direction": {
+          "enabled_states": [
+            "minecraft:cardinal_direction"
+          ],
+          "y_rotation_offset": 0.0
         }
-    }
+      }
+    },
+    "permutations": [
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
+        "components": {
+          "minecraft:geometry": "geometry.honey_glazed_ham_block_stage0"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
+        "components": {
+          "minecraft:geometry": "geometry.honey_glazed_ham_block_stage1",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/honey_glazed_ham_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
+        "components": {
+          "minecraft:geometry": "geometry.honey_glazed_ham_block_stage2",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/honey_glazed_ham_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
+        "components": {
+          "minecraft:geometry": "geometry.honey_glazed_ham_block_stage3",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/honey_glazed_ham_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
+        "components": {
+          "minecraft:geometry": "geometry.honey_glazed_ham_block_leftover",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/honey_glazed_ham_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              180,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              270,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              90,
+              0
+            ]
+          }
+        }
+      }
+    ],
+    "components": {
+      "minecraft:geometry": "geometry.honey_glazed_ham_block_stage0",
+      "minecraft:redstone_conductivity": {
+        "allows_wire_to_step_down": false
+      },
+      "minecraft:destructible_by_mining": {
+        "seconds_to_destroy": 1.0
+      },
+      "minecraft:light_dampening": 0,
+      "minecraft:destructible_by_explosion": {
+        "explosion_resistance": 0.25
+      },
+      "minecraft:material_instances": {
+        "*": {
+          "texture": "honey_glazed_ham_body"
+        },
+        "honey_glazed_ham_bone": {
+          "texture": "honey_glazed_ham_bone"
+        },
+        "honey_glazed_ham_body": {
+          "texture": "honey_glazed_ham_body"
+        },
+        "tray_bottom": {
+          "texture": "tray_bottom"
+        },
+        "tray_rice_berry_garnish": {
+          "texture": "tray_rice_berry_garnish"
+        },
+        "tray_rice_berry_leftover": {
+          "texture": "tray_rice_berry_leftover"
+        }
+      },
+      "minecraft:collision_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          10.0,
+          14.0
+        ]
+      },
+      "minecraft:selection_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          10.0,
+          14.0
+        ]
+      },
+      "farmersdelight:dish": {
+        "has_leftovers": true,
+        "servings": 4,
+        "contents": "farmersdelight:honey_glazed_ham",
+        "utensil": "minecraft:bowl"
+      },
+      "minecraft:loot": "loot_tables/farmersdelight/dish/honey_glazed_ham_block.json"
+    },
+    "tag:farmersdelight:blockfood": {}
+  }
 }

--- a/B/blocks/rice_roll_medley_block.json
+++ b/B/blocks/rice_roll_medley_block.json
@@ -1,198 +1,211 @@
 {
-    "format_version": "1.21.120",
-    "minecraft:block": {
-        "description": {
-            "identifier": "farmersdelight:rice_roll_medley_block",
-            "menu_category": {
-                "category": "none"
-            },
-            "states": {
-                "farmersdelight:food_block_stage": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8
-                ]
-            },
-            "traits": {
-                "minecraft:placement_direction": {
-                    "enabled_states": [
-                        "minecraft:cardinal_direction"
-                    ],
-                    "y_rotation_offset": 0.0
-                }
-            }
-        },
-        "permutations": [
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage0"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage1"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage2"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage3"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage4"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 5",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage5"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 6",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage6"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 7",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_stage7"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 8",
-                "components": {
-                    "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
-                    "minecraft:geometry": "geometry.rice_roll_medley_block_leftover"
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            180,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            0,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            270,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            90,
-                            0
-                        ]
-                    }
-                }
-            }
-        ],
-        "components": {
-            "minecraft:geometry": "geometry.rice_roll_medley_block_stage0",
-            "minecraft:destructible_by_mining": {
-                "seconds_to_destroy": 1.0
-            },
-            "minecraft:light_dampening": 0,
-            "minecraft:destructible_by_explosion": {
-                "explosion_resistance": 0.25
-            },
-            "farmersdelight:rice_roll_medley": {},
-            "minecraft:material_instances": {
-                "*": {
-                    "texture": "rice_roll_medley",
-                    "render_method": "alpha_test"
-                },
-                "rice_roll_medley": {
-                    "texture": "rice_roll_medley",
-                    "render_method": "alpha_test"
-                },
-                "tray_bottom": {
-                    "texture": "tray_bottom",
-                    "render_method": "alpha_test"
-                },
-                "tray_top": {
-                    "texture": "tray_top",
-                    "render_method": "alpha_test"
-                }
-            },
-            "minecraft:collision_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    4.0,
-                    14.0
-                ]
-            },
-            "minecraft:selection_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    4.0,
-                    14.0
-                ]
-            }
+  "format_version": "1.21.120",
+  "minecraft:block": {
+    "description": {
+      "identifier": "farmersdelight:rice_roll_medley_block",
+      "menu_category": {
+        "category": "none"
+      },
+      "states": {
+        "farmersdelight:food_block_stage": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ]
+      },
+      "traits": {
+        "minecraft:placement_direction": {
+          "enabled_states": [
+            "minecraft:cardinal_direction"
+          ],
+          "y_rotation_offset": 0.0
         }
+      }
+    },
+    "permutations": [
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage0"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage1"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage2"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage3"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage4"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 5",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage5"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 6",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage6"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 7",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_stage7"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 8",
+        "components": {
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/rice_roll_medley_block_over.json",
+          "minecraft:geometry": "geometry.rice_roll_medley_block_leftover"
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              180,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              270,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              90,
+              0
+            ]
+          }
+        }
+      }
+    ],
+    "components": {
+      "minecraft:geometry": "geometry.rice_roll_medley_block_stage0",
+      "minecraft:destructible_by_mining": {
+        "seconds_to_destroy": 1.0
+      },
+      "minecraft:light_dampening": 0,
+      "minecraft:destructible_by_explosion": {
+        "explosion_resistance": 0.25
+      },
+      "farmersdelight:dish": {
+        "has_leftovers": true,
+        "servings": 8,
+        "contents": [
+          "farmersdelight:kelp_roll_slice",
+          "farmersdelight:kelp_roll_slice",
+          "farmersdelight:kelp_roll_slice",
+          "farmersdelight:salmon_roll",
+          "farmersdelight:salmon_roll",
+          "farmersdelight:salmon_roll",
+          "farmersdelight:cod_roll",
+          "farmersdelight:cod_roll"
+        ]
+      },
+      "minecraft:material_instances": {
+        "*": {
+          "texture": "rice_roll_medley",
+          "render_method": "alpha_test"
+        },
+        "rice_roll_medley": {
+          "texture": "rice_roll_medley",
+          "render_method": "alpha_test"
+        },
+        "tray_bottom": {
+          "texture": "tray_bottom",
+          "render_method": "alpha_test"
+        },
+        "tray_top": {
+          "texture": "tray_top",
+          "render_method": "alpha_test"
+        }
+      },
+      "minecraft:collision_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          4.0,
+          14.0
+        ]
+      },
+      "minecraft:selection_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          4.0,
+          14.0
+        ]
+      }
     }
+  }
 }

--- a/B/blocks/roast_chicken_block.json
+++ b/B/blocks/roast_chicken_block.json
@@ -1,175 +1,184 @@
 {
-    "format_version": "1.21.120",
-    "minecraft:block": {
-        "description": {
-            "identifier": "farmersdelight:roast_chicken_block",
-            "menu_category": {
-                "category": "none"
-            },
-            "states": {
-                "farmersdelight:food_block_stage": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4
-                ]
-            },
-            "traits": {
-                "minecraft:placement_direction": {
-                    "enabled_states": [
-                        "minecraft:cardinal_direction"
-                    ],
-                    "y_rotation_offset": 0.0
-                }
-            }
-        },
-        "permutations": [
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
-                "components": {
-                    "minecraft:geometry": "geometry.roast_chicken_block_stage0",
-                    "tag:farmersdelight:use_bowl": {}
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
-                "components": {
-                    "minecraft:geometry": "geometry.roast_chicken_block_stage1"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
-                "components": {
-                    "minecraft:geometry": "geometry.roast_chicken_block_stage2"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
-                "components": {
-                    "minecraft:geometry": "geometry.roast_chicken_block_stage3"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
-                "components": {
-                    "minecraft:geometry": "geometry.roast_chicken_block_leftover"
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            180,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            0,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            270,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            90,
-                            0
-                        ]
-                    }
-                }
-            }
-        ],
-        "components": {
-            "minecraft:geometry": "geometry.roast_chicken_block_stage0",
-            "minecraft:redstone_conductivity": {
-                "allows_wire_to_step_down": false
-            },
-            "farmersdelight:interact": {},
-            "minecraft:destructible_by_mining": {
-                "seconds_to_destroy": 1.0
-            },
-            "minecraft:light_dampening": 0,
-            "minecraft:destructible_by_explosion": {
-                "explosion_resistance": 0.25
-            },
-            "minecraft:material_instances": {
-                "*": {
-                    "texture": "roast_chicken_eaten",
-                    "render_method": "alpha_test"
-                },
-                "roast_chicken_eaten": {
-                    "texture": "roast_chicken_eaten",
-                    "render_method": "alpha_test"
-                },
-                "roast_chicken_gibs": {
-                    "texture": "roast_chicken_gibs",
-                    "render_method": "alpha_test"
-                },
-                "tray_bottom": {
-                    "texture": "tray_bottom",
-                    "render_method": "alpha_test"
-                },
-                "tray_top_veggies": {
-                    "texture": "tray_top_veggies",
-                    "render_method": "alpha_test"
-                },
-                "tray_top_leftover": {
-                    "texture": "tray_top_leftover",
-                    "render_method": "alpha_test"
-                }
-            },
-            "minecraft:collision_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    9.0,
-                    14.0
-                ]
-            },
-            "minecraft:selection_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    9.0,
-                    14.0
-                ]
-            },
-            "tag:farmersdelight.blockfood:4-item.minecraft:bowl": {},
-            "tag:farmersdelight:blockfood": {}
+  "format_version": "1.21.120",
+  "minecraft:block": {
+    "description": {
+      "identifier": "farmersdelight:roast_chicken_block",
+      "menu_category": {
+        "category": "none"
+      },
+      "states": {
+        "farmersdelight:food_block_stage": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      "traits": {
+        "minecraft:placement_direction": {
+          "enabled_states": [
+            "minecraft:cardinal_direction"
+          ],
+          "y_rotation_offset": 0.0
         }
+      }
+    },
+    "permutations": [
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
+        "components": {
+          "minecraft:geometry": "geometry.roast_chicken_block_stage0",
+          "tag:farmersdelight:use_bowl": {}
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
+        "components": {
+          "minecraft:geometry": "geometry.roast_chicken_block_stage1",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/roast_chicken_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
+        "components": {
+          "minecraft:geometry": "geometry.roast_chicken_block_stage2",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/roast_chicken_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
+        "components": {
+          "minecraft:geometry": "geometry.roast_chicken_block_stage3",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/roast_chicken_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
+        "components": {
+          "minecraft:geometry": "geometry.roast_chicken_block_leftover",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/roast_chicken_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              180,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              270,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              90,
+              0
+            ]
+          }
+        }
+      }
+    ],
+    "components": {
+      "minecraft:geometry": "geometry.roast_chicken_block_stage0",
+      "minecraft:redstone_conductivity": {
+        "allows_wire_to_step_down": false
+      },
+      "farmersdelight:dish": {
+        "has_leftovers": true,
+        "servings": 4,
+        "contents": "farmersdelight:roast_chicken",
+        "utensil": "minecraft:bowl"
+      },
+      "minecraft:loot": "loot_tables/farmersdelight/dish/roast_chicken_block.json",
+      "minecraft:destructible_by_mining": {
+        "seconds_to_destroy": 1.0
+      },
+      "minecraft:light_dampening": 0,
+      "minecraft:destructible_by_explosion": {
+        "explosion_resistance": 0.25
+      },
+      "minecraft:material_instances": {
+        "*": {
+          "texture": "roast_chicken_eaten",
+          "render_method": "alpha_test"
+        },
+        "roast_chicken_eaten": {
+          "texture": "roast_chicken_eaten",
+          "render_method": "alpha_test"
+        },
+        "roast_chicken_gibs": {
+          "texture": "roast_chicken_gibs",
+          "render_method": "alpha_test"
+        },
+        "tray_bottom": {
+          "texture": "tray_bottom",
+          "render_method": "alpha_test"
+        },
+        "tray_top_veggies": {
+          "texture": "tray_top_veggies",
+          "render_method": "alpha_test"
+        },
+        "tray_top_leftover": {
+          "texture": "tray_top_leftover",
+          "render_method": "alpha_test"
+        }
+      },
+      "minecraft:collision_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          9.0,
+          14.0
+        ]
+      },
+      "minecraft:selection_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          9.0,
+          14.0
+        ]
+      },
+      "tag:farmersdelight:blockfood": {}
     }
+  }
 }

--- a/B/blocks/shepherds_pie_block.json
+++ b/B/blocks/shepherds_pie_block.json
@@ -1,168 +1,177 @@
 {
-    "format_version": "1.21.120",
-    "minecraft:block": {
-        "description": {
-            "identifier": "farmersdelight:shepherds_pie_block",
-            "menu_category": {
-                "category": "none"
-            },
-            "states": {
-                "farmersdelight:food_block_stage": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4
-                ]
-            },
-            "traits": {
-                "minecraft:placement_direction": {
-                    "enabled_states": [
-                        "minecraft:cardinal_direction"
-                    ],
-                    "y_rotation_offset": 0.0
-                }
-            }
-        },
-        "permutations": [
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
-                "components": {
-                    "minecraft:geometry": "geometry.shepherds_pie_block_stage0"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
-                "components": {
-                    "minecraft:geometry": "geometry.shepherds_pie_block_stage1"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
-                "components": {
-                    "minecraft:geometry": "geometry.shepherds_pie_block_stage2"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
-                "components": {
-                    "minecraft:geometry": "geometry.shepherds_pie_block_stage3"
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
-                "components": {
-                    "minecraft:geometry": "geometry.shepherds_pie_block_leftover"
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            180,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            0,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            270,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            90,
-                            0
-                        ]
-                    }
-                }
-            }
-        ],
-        "components": {
-            "minecraft:redstone_conductivity": {
-                "allows_wire_to_step_down": false
-            },
-            "farmersdelight:interact": {},
-            "minecraft:destructible_by_mining": {
-                "seconds_to_destroy": 1.0
-            },
-            "minecraft:light_dampening": 0,
-            "minecraft:destructible_by_explosion": {
-                "explosion_resistance": 0.25
-            },
-            "minecraft:geometry": "geometry.shepherds_pie_block_stage0",
-            "minecraft:material_instances": {
-                "*": {
-                    "texture": "shepherds_pie_side"
-                },
-                "shepherds_pie_top": {
-                    "texture": "shepherds_pie_top"
-                },
-                "shepherds_pie_side": {
-                    "texture": "shepherds_pie_side"
-                },
-                "tray_bottom": {
-                    "texture": "tray_bottom"
-                },
-                "shepherds_pie_inner": {
-                    "texture": "shepherds_pie_inner"
-                },
-                "tray_pie_leftover": {
-                    "texture": "tray_pie_leftover"
-                }
-            },
-            "minecraft:collision_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    8.0,
-                    14.0
-                ]
-            },
-            "minecraft:selection_box": {
-                "origin": [
-                    -7.0,
-                    0.0,
-                    -7.0
-                ],
-                "size": [
-                    14.0,
-                    8.0,
-                    14.0
-                ]
-            },
-            "tag:farmersdelight.blockfood:4-item.minecraft:bowl": {},
-            "tag:farmersdelight:blockfood": {}
+  "format_version": "1.21.120",
+  "minecraft:block": {
+    "description": {
+      "identifier": "farmersdelight:shepherds_pie_block",
+      "menu_category": {
+        "category": "none"
+      },
+      "states": {
+        "farmersdelight:food_block_stage": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      "traits": {
+        "minecraft:placement_direction": {
+          "enabled_states": [
+            "minecraft:cardinal_direction"
+          ],
+          "y_rotation_offset": 0.0
         }
+      }
+    },
+    "permutations": [
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
+        "components": {
+          "minecraft:geometry": "geometry.shepherds_pie_block_stage0"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
+        "components": {
+          "minecraft:geometry": "geometry.shepherds_pie_block_stage1",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/shepherds_pie_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
+        "components": {
+          "minecraft:geometry": "geometry.shepherds_pie_block_stage2",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/shepherds_pie_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
+        "components": {
+          "minecraft:geometry": "geometry.shepherds_pie_block_stage3",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/shepherds_pie_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 4",
+        "components": {
+          "minecraft:geometry": "geometry.shepherds_pie_block_leftover",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/shepherds_pie_block_over.json"
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              180,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              270,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              90,
+              0
+            ]
+          }
+        }
+      }
+    ],
+    "components": {
+      "minecraft:redstone_conductivity": {
+        "allows_wire_to_step_down": false
+      },
+      "farmersdelight:dish": {
+        "has_leftovers": true,
+        "servings": 4,
+        "contents": "farmersdelight:shepherds_pie",
+        "utensil": "minecraft:bowl"
+      },
+      "minecraft:loot": "loot_tables/farmersdelight/dish/shepherds_pie_block.json",
+      "minecraft:destructible_by_mining": {
+        "seconds_to_destroy": 1.0
+      },
+      "minecraft:light_dampening": 0,
+      "minecraft:destructible_by_explosion": {
+        "explosion_resistance": 0.25
+      },
+      "minecraft:geometry": "geometry.shepherds_pie_block_stage0",
+      "minecraft:material_instances": {
+        "*": {
+          "texture": "shepherds_pie_side"
+        },
+        "shepherds_pie_top": {
+          "texture": "shepherds_pie_top"
+        },
+        "shepherds_pie_side": {
+          "texture": "shepherds_pie_side"
+        },
+        "tray_bottom": {
+          "texture": "tray_bottom"
+        },
+        "shepherds_pie_inner": {
+          "texture": "shepherds_pie_inner"
+        },
+        "tray_pie_leftover": {
+          "texture": "tray_pie_leftover"
+        }
+      },
+      "minecraft:collision_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          8.0,
+          14.0
+        ]
+      },
+      "minecraft:selection_box": {
+        "origin": [
+          -7.0,
+          0.0,
+          -7.0
+        ],
+        "size": [
+          14.0,
+          8.0,
+          14.0
+        ]
+      },
+      "tag:farmersdelight:blockfood": {}
     }
+  }
 }

--- a/B/blocks/stuffed_pumpkin_block.json
+++ b/B/blocks/stuffed_pumpkin_block.json
@@ -1,230 +1,237 @@
 {
-    "format_version": "1.21.120",
-    "minecraft:block": {
-        "description": {
-            "identifier": "farmersdelight:stuffed_pumpkin_block",
-            "menu_category": {
-                "category": "none"
-            },
-            "states": {
-                "farmersdelight:food_block_stage": [
-                    0,
-                    1,
-                    2,
-                    3
-                ]
-            },
-            "traits": {
-                "minecraft:placement_direction": {
-                    "enabled_states": [
-                        "minecraft:cardinal_direction"
-                    ],
-                    "y_rotation_offset": 0.0
-                }
-            }
-        },
-        "permutations": [
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
-                "components": {
-                    "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage0",
-                    "minecraft:collision_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            12.0,
-                            12.0
-                        ]
-                    },
-                    "minecraft:selection_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            12.0,
-                            12.0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
-                "components": {
-                    "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage1",
-                    "minecraft:collision_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            12.0,
-                            12.0
-                        ]
-                    },
-                    "minecraft:selection_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            10.0,
-                            12.0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
-                "components": {
-                    "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage2",
-                    "minecraft:collision_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            12.0,
-                            12.0
-                        ]
-                    },
-                    "minecraft:selection_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            8.0,
-                            12.0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
-                "components": {
-                    "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage3",
-                    "minecraft:collision_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            12.0,
-                            12.0
-                        ]
-                    },
-                    "minecraft:selection_box": {
-                        "origin": [
-                            -6.0,
-                            0.0,
-                            -6.0
-                        ],
-                        "size": [
-                            12.0,
-                            4.0,
-                            12.0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            180,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            0,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            270,
-                            0
-                        ]
-                    }
-                }
-            },
-            {
-                "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
-                "components": {
-                    "minecraft:transformation": {
-                        "rotation": [
-                            0,
-                            90,
-                            0
-                        ]
-                    }
-                }
-            }
-        ],
-        "components": {
-            "minecraft:redstone_conductivity":{
-                "allows_wire_to_step_down": false
-            },
-            "farmersdelight:interact":{},
-            "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage0",
-            "minecraft:destructible_by_mining": {
-                "seconds_to_destroy": 1.0
-            },
-            "minecraft:light_dampening": 0,
-            "minecraft:destructible_by_explosion": {
-                "explosion_resistance": 0.25
-            },
-            "minecraft:material_instances": {
-                "*": {
-                    "texture": "stuffed_pumpkin_bottom"
-                },
-                "stuffed_pumpkin_bottom": {
-                    "texture": "stuffed_pumpkin_bottom"
-                },
-                "stuffed_pumpkin_details": {
-                    "texture": "stuffed_pumpkin_details"
-                },
-                "stuffed_pumpkin_side": {
-                    "texture": "stuffed_pumpkin_side"
-                },
-                "stuffed_pumpkin_top_eaten": {
-                    "texture": "stuffed_pumpkin_top_eaten"
-                }
-            },
-            "tag:farmersdelight.blockfood:3-item.minecraft:bowl": {},
-            "tag:farmersdelight:blockfood": {}
+  "format_version": "1.21.120",
+  "minecraft:block": {
+    "description": {
+      "identifier": "farmersdelight:stuffed_pumpkin_block",
+      "menu_category": {
+        "category": "none"
+      },
+      "states": {
+        "farmersdelight:food_block_stage": [
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      "traits": {
+        "minecraft:placement_direction": {
+          "enabled_states": [
+            "minecraft:cardinal_direction"
+          ],
+          "y_rotation_offset": 0.0
         }
+      }
+    },
+    "permutations": [
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 0",
+        "components": {
+          "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage0",
+          "minecraft:collision_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              12.0,
+              12.0
+            ]
+          },
+          "minecraft:selection_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              12.0,
+              12.0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 1",
+        "components": {
+          "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage1",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/stuffed_pumpkin_block_over.json",
+          "minecraft:collision_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              12.0,
+              12.0
+            ]
+          },
+          "minecraft:selection_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              10.0,
+              12.0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 2",
+        "components": {
+          "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage2",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/stuffed_pumpkin_block_over.json",
+          "minecraft:collision_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              12.0,
+              12.0
+            ]
+          },
+          "minecraft:selection_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              8.0,
+              12.0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('farmersdelight:food_block_stage') == 3",
+        "components": {
+          "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage3",
+          "minecraft:loot": "loot_tables/farmersdelight/food_block/stuffed_pumpkin_block_over.json",
+          "minecraft:collision_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              12.0,
+              12.0
+            ]
+          },
+          "minecraft:selection_box": {
+            "origin": [
+              -6.0,
+              0.0,
+              -6.0
+            ],
+            "size": [
+              12.0,
+              4.0,
+              12.0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'north'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              180,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'south'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              0,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'west'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              270,
+              0
+            ]
+          }
+        }
+      },
+      {
+        "condition": "query.block_state('minecraft:cardinal_direction') == 'east'",
+        "components": {
+          "minecraft:transformation": {
+            "rotation": [
+              0,
+              90,
+              0
+            ]
+          }
+        }
+      }
+    ],
+    "components": {
+      "minecraft:redstone_conductivity": {
+        "allows_wire_to_step_down": false
+      },
+      "farmersdelight:dish": {
+        "servings": 4,
+        "contents": "farmersdelight:stuffed_pumpkin",
+        "utensil": "minecraft:bowl"
+      },
+      "minecraft:loot": "loot_tables/farmersdelight/dish/stuffed_pumpkin_block.json",
+      "minecraft:geometry": "geometry.stuffed_pumpkin_block_stage0",
+      "minecraft:destructible_by_mining": {
+        "seconds_to_destroy": 1.0
+      },
+      "minecraft:light_dampening": 0,
+      "minecraft:destructible_by_explosion": {
+        "explosion_resistance": 0.25
+      },
+      "minecraft:material_instances": {
+        "*": {
+          "texture": "stuffed_pumpkin_bottom"
+        },
+        "stuffed_pumpkin_bottom": {
+          "texture": "stuffed_pumpkin_bottom"
+        },
+        "stuffed_pumpkin_details": {
+          "texture": "stuffed_pumpkin_details"
+        },
+        "stuffed_pumpkin_side": {
+          "texture": "stuffed_pumpkin_side"
+        },
+        "stuffed_pumpkin_top_eaten": {
+          "texture": "stuffed_pumpkin_top_eaten"
+        }
+      },
+      "tag:farmersdelight:blockfood": {}
     }
+  }
 }

--- a/B/loot_tables/farmersdelight/dish/honey_glazed_ham_block.json
+++ b/B/loot_tables/farmersdelight/dish/honey_glazed_ham_block.json
@@ -1,0 +1,13 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "item",
+          "name": "farmersdelight:honey_glazed_ham_block_item"
+        }
+      ]
+    }
+  ]
+}

--- a/B/loot_tables/farmersdelight/dish/roast_chicken_block.json
+++ b/B/loot_tables/farmersdelight/dish/roast_chicken_block.json
@@ -1,0 +1,13 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "item",
+          "name": "farmersdelight:roast_chicken_block_item"
+        }
+      ]
+    }
+  ]
+}

--- a/B/loot_tables/farmersdelight/dish/shepherds_pie_block.json
+++ b/B/loot_tables/farmersdelight/dish/shepherds_pie_block.json
@@ -1,0 +1,13 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "item",
+          "name": "farmersdelight:shepherds_pie_block_item"
+        }
+      ]
+    }
+  ]
+}

--- a/B/loot_tables/farmersdelight/dish/stuffed_pumpkin_block.json
+++ b/B/loot_tables/farmersdelight/dish/stuffed_pumpkin_block.json
@@ -1,0 +1,13 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "item",
+          "name": "farmersdelight:stuffed_pumpkin_block_item"
+        }
+      ]
+    }
+  ]
+}

--- a/B/loot_tables/farmersdelight/food_block/roast_chicken_block_over.json
+++ b/B/loot_tables/farmersdelight/food_block/roast_chicken_block_over.json
@@ -14,7 +14,7 @@
             "entries": [
                 {
                     "type": "item",
-                    "name": "minecraft:bone"
+                    "name": "minecraft:bone_meal"
                 }
             ]
         }

--- a/B/typescripts/block/BlockFood.ts
+++ b/B/typescripts/block/BlockFood.ts
@@ -1,6 +1,19 @@
-import { Block, Container, Dimension, EntityInventoryComponent, ItemStack, Player, PlayerBreakBlockBeforeEvent, PlayerInteractWithBlockAfterEvent, Vector3, system, world } from "@minecraft/server";
-import { methodEventSub } from "../lib/eventHelper";
+import {
+    Block,
+    Container,
+    Dimension,
+    EntityInventoryComponent,
+    ItemStack,
+    Player,
+    PlayerBreakBlockBeforeEvent,
+    PlayerInteractWithBlockAfterEvent,
+    system,
+    Vector3,
+    world,
+} from "@minecraft/server";
 import { ItemUtil } from "../lib/ItemUtil";
+import { methodEventSub } from "../lib/eventHelper";
+
 function spawnLoot(path: string, dimenion: Dimension, location: Vector3) {
     return dimenion.runCommand(`loot spawn ${location.x} ${location.y} ${location.z} loot "${path}"`)
 }
@@ -56,36 +69,16 @@ export class BlockFood {
         const block: Block = args.block;
         const location = args.block.location;
         const player: Player = args.player;
-        const blockFoodAllTag = block.getTags();
         const inventory = args.player?.getComponent("inventory") as EntityInventoryComponent;
         const container: Container | undefined = inventory?.container
         if (!container) return;
-        for (const tag of blockFoodAllTag) {
-            if (tag == "farmersdelight:blockfood") {
-                if (Number(block.permutation.getState("farmersdelight:food_block_stage")) != 0) {
-                    system.run(() => {
-                        block.dimension.setBlockType({ x: location.x, y: location.y, z: location.z }, "minecraft:air")
-
-                    });
-                };
-                if (Number(block.permutation.getState("farmersdelight:food_block_stage")) == 0) {
-                    system.run(() => {
-                        block.dimension.spawnItem(new ItemStack(block.typeId + "_item"), block.location);
-                        block.dimension.setBlockType({ x: location.x, y: location.y, z: location.z }, "minecraft:air")
-                        player.playSound("dig.cloth")
-                        ItemUtil.damageItem(container, player.selectedSlotIndex)
-                    });
-                }
-                args.cancel = true;
-            };
-        }
-        if (block.typeId == "farmersdelight:rice_roll_medley_block") {
+        if (block.hasTag("farmersdelight:blockfood") && !block.getComponent("farmersdelight:dish")) {
             if (Number(block.permutation.getState("farmersdelight:food_block_stage")) != 0) {
                 system.run(() => {
                     block.dimension.setBlockType({ x: location.x, y: location.y, z: location.z }, "minecraft:air")
 
                 });
-            };
+            }
             if (Number(block.permutation.getState("farmersdelight:food_block_stage")) == 0) {
                 system.run(() => {
                     block.dimension.spawnItem(new ItemStack(block.typeId + "_item"), block.location);
@@ -95,6 +88,6 @@ export class BlockFood {
                 });
             }
             args.cancel = true;
-        };
+        }
     }
 }

--- a/B/typescripts/customComponents/block/DishComponent.ts
+++ b/B/typescripts/customComponents/block/DishComponent.ts
@@ -1,0 +1,102 @@
+import {
+    BlockComponentPlayerInteractEvent,
+    BlockCustomComponent,
+    ContainerSlot,
+    CustomComponentParameters,
+    EntityComponentTypes,
+    GameMode,
+    ItemStack, ItemTypes,
+    StartupEvent,
+    system, world,
+} from "@minecraft/server";
+import { methodEventSub } from "../../lib/eventHelper";
+
+interface DishSpec {
+    has_leftovers?: boolean,
+    servings?: number
+    contents?: string | string[],
+    utensil?: string // allows #tag
+}
+
+function requiresItem(tagOrId: string): string {
+    return "farmersdelight.blockfood." + (tagOrId[0] === "#" ? tagOrId.substring(1) : tagOrId); // sic
+}
+
+function isInvalidItem(slot: ContainerSlot, tagOrId: string): boolean {
+    const stack = slot.getItem();
+    if (!stack) return true;
+    return tagOrId[0] === "#" ? !stack.hasTag(tagOrId.substring(1)) : stack.typeId !== tagOrId;
+}
+
+export class DishComponent implements BlockCustomComponent {
+    onPlayerInteract(event: BlockComponentPlayerInteractEvent, params: CustomComponentParameters) {
+        const spec = params.params as DishSpec;
+        const servings = spec.servings ?? 1;
+        const player = event.player;
+        const container = player?.getComponent(EntityComponentTypes.Inventory)?.container;
+        const block = event.block;
+        const permutation = block.permutation;
+        const consumed = permutation.getState("farmersdelight:food_block_stage") ?? servings;
+        if (consumed >= servings && spec.has_leftovers) {
+            const stacks = world.getLootTableManager().generateLootFromBlockPermutation(permutation);
+            if (stacks) {
+                const dimension = block.dimension;
+                const pos = block.bottomCenter();
+                for (const stack of stacks) {
+                    dimension.spawnItem(stack, pos);
+                }
+            }
+            block.setType("minecraft:air");
+            return;
+        }
+        let slot: ContainerSlot | undefined;
+        if (spec.utensil) {
+            if (!player) return;
+            slot = container?.getSlot(player.selectedSlotIndex);
+            if (!slot || isInvalidItem(slot, spec.utensil)) {
+                player.onScreenDisplay.setActionBar({ translate: requiresItem(spec.utensil) });
+                return;
+            }
+        }
+        let content = spec.contents;
+        if (Array.isArray(content)) {
+            content = content[consumed];
+            if (!content) {
+                // 这里要不要打个日志
+                content = (spec.contents as string[])[0];
+            }
+        }
+        const item = content ? ItemTypes.get(content) : undefined;
+        if (!item) {
+            console.warn("Filed to fetch item indexed", consumed);
+            return;
+        }
+        if (container) {
+            const remaining = container.addItem(new ItemStack(item));
+            if (remaining) {
+                block.dimension.spawnItem(remaining, block.bottomCenter());
+            }
+        } else {
+            block.dimension.spawnItem(new ItemStack(item), block.bottomCenter());
+        }
+        if (consumed + 1 < servings || spec.has_leftovers) {
+            block.setPermutation(permutation.withState("farmersdelight:food_block_stage", consumed + 1));
+        } else {
+            block.setType("minecraft:air");
+        }
+        if (!slot || player?.getGameMode() === GameMode.Creative) return;
+        const amount = slot.amount - 1;
+        if (amount) {
+            slot.amount = amount;
+        } else {
+            slot.setItem(undefined);
+        }
+    }
+
+    @methodEventSub(system.beforeEvents.startup)
+    static init(event: StartupEvent) {
+        event.blockComponentRegistry.registerCustomComponent("farmersdelight:dish", new DishComponent());
+    }
+}
+
+void DishComponent;

--- a/B/typescripts/customComponents/block/DishComponent.ts
+++ b/B/typescripts/customComponents/block/DishComponent.ts
@@ -49,13 +49,20 @@ export class DishComponent implements BlockCustomComponent {
             block.setType("minecraft:air");
             return;
         }
-        let slot: ContainerSlot | undefined;
         if (spec.utensil) {
             if (!player) return;
-            slot = container?.getSlot(player.selectedSlotIndex);
+            const slot = container?.getSlot(player.selectedSlotIndex);
             if (!slot || isInvalidItem(slot, spec.utensil)) {
                 player.onScreenDisplay.setActionBar({ translate: requiresItem(spec.utensil) });
                 return;
+            }
+            if (player.getGameMode() !== GameMode.Creative) {
+                const amount = slot.amount - 1;
+                if (amount) {
+                    slot.amount = amount;
+                } else {
+                    slot.setItem(undefined);
+                }
             }
         }
         let content = spec.contents;
@@ -83,13 +90,6 @@ export class DishComponent implements BlockCustomComponent {
             block.setPermutation(permutation.withState("farmersdelight:food_block_stage", consumed + 1));
         } else {
             block.setType("minecraft:air");
-        }
-        if (!slot || player?.getGameMode() === GameMode.Creative) return;
-        const amount = slot.amount - 1;
-        if (amount) {
-            slot.amount = amount;
-        } else {
-            slot.setItem(undefined);
         }
     }
 

--- a/B/typescripts/customComponents/item/KnifeComponent.ts
+++ b/B/typescripts/customComponents/item/KnifeComponent.ts
@@ -106,4 +106,4 @@ class KnifeComponent implements ItemCustomComponent {
     }
 }
 
-export const {} = KnifeComponent;
+void KnifeComponent;

--- a/B/typescripts/main.ts
+++ b/B/typescripts/main.ts
@@ -41,6 +41,7 @@ import { PieComponent } from "./customComponents/block/PieCompostComonent";
 import { Basket } from "./block/basket/Basket";
 import { BasketBlockEntity } from "./block/basket/BasketBlockEntity";
 import "./customComponents/item/KnifeComponent"
+import "./customComponents/block/DishComponent"
 
 CookingPotRecipeRegistries.initCookingPotScoRegistries();
 CuttingBoardRegistries.initCuttingBoardScoRegistries();


### PR DESCRIPTION
## 新内容
- 新增`farmersdelight:dish`方块组件，该组件依赖`farmersdelight:food_block_stage`方块状态
  - `servings`: `number?`
    - 可选字段，方块会返回物品的交互次数
  - `contents`: `string | string[]`
    - 必填字段，声明每次交互返回的物品
  - `utensil`: `string?`
    - 可选字段，限制玩家交互时所用物品，支持使用以`#`开头的字符串使用标签
  - `has_leftovers`: `boolean?`
    - 可选字段，控制交互过程中方块的破坏时机以及破坏方块的同时是否掉落物品

## 行为变更
- 烤鸡、填馅南瓜、蜜汁火腿、牧羊人派、寿司拼盘在交互时会优先将物品放入物品栏

## 修复
- 现在烤鸡、填馅南瓜、蜜汁火腿、牧羊人派会掉落其物品形式
- 食用的过的烤鸡被破坏时现在掉落骨粉而不是骨头

## 兼容
- 暂时保留对未适配`farmersdelight:dish`组件的含有`farmersdelight:blockfood`标签的方块的破坏拦截
- 暂时保留对`farmersdelight.blockfood`命名空间的标签解析
- 暂时保留`farmersdelight:rice_roll_medley`组件的注册
- 暂时保留相关的战利品表

## 破坏性变更
- 移除了烤鸡、填馅南瓜、蜜汁火腿、牧羊人派上`farmersdelight.blockfood`命名空间的标签
- 移除了烤鸡、填馅南瓜、蜜汁火腿、牧羊人派的`farmersdelight:interact`组件
  - `farmersdelight:dish`组件实现了`onPlayerInteract`
- 移除了寿司拼盘的`farmersdelight:rice_roll_medley`组件